### PR TITLE
Add support for Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: scala
 scala:
-  - 2.12.0
-  - 2.12.1
-  - 2.12.2
+  - 2.12.10
+  - 2.13.3
 jdk:
-  - oraclejdk8
+  - openjdk11
 cache:
   directories:
     - $HOME/.ivy2/cache

--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ A Scala library for representing versions as objects
 
 ### SBT
 
+**Scala 2.13**
+
+```sbtshell
+"com.nthportal" %% "versions" % "2.0.2"
+```
+
 **Scala 2.12**
 
 ```sbtshell
-"com.nthportal" %% "versions" % "2.0.1"
+"com.nthportal" %% "versions" % "2.0.2"
 ```
 
 **Scala 2.11**
@@ -24,6 +30,16 @@ A Scala library for representing versions as objects
 ```
 
 ### Maven
+
+**Scala 2.13**
+
+```xml
+<dependency>
+  <groupId>com.nthportal</groupId>
+  <artifactId>versions_2.13</artifactId>
+  <version>2.0.2</version>
+</dependency>
+```
 
 **Scala 2.12**
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,20 +2,19 @@ organization := "com.nthportal"
 name := "versions"
 description := "A Scala library for representing versions as objects."
 
-val rawVersion = "2.0.1"
+val rawVersion = "2.0.2"
 isSnapshot := false
 version := rawVersion + { if (isSnapshot.value) "-SNAPSHOT" else "" }
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.10"
 crossScalaVersions := Seq(
-  "2.12.0",
-  "2.12.1",
-  "2.12.2"
+  "2.12.10",
+  "2.13.3"
 )
 
 libraryDependencies ++= Seq(
-  "com.nthportal" %% "extra-predef" % "1.+",
-  "org.scalatest" %% "scalatest" % "3.0.+" % Test
+  "com.nthportal" %% "extra-predef" % "1.1.1+",
+  "org.scalatest" %% "scalatest" % "3.1.+" % Test
 )
 
 scalacOptions ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossScalaVersions := Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.nthportal" %% "extra-predef" % "2.0.0",
+  "com.nthportal" %% "extra-predef" % "2.1.0",
   "org.scalatest" %% "scalatest" % "3.1.+" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossScalaVersions := Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.nthportal" %% "extra-predef" % "1.1.1+",
+  "com.nthportal" %% "extra-predef" % "2.0.0",
   "org.scalatest" %% "scalatest" % "3.1.+" % Test
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,2 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
 logLevel := Level.Warn
 
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/src/main/scala/com/nthportal/versions/v2/Version.scala
+++ b/src/main/scala/com/nthportal/versions/v2/Version.scala
@@ -21,7 +21,8 @@ final case class Version(major: Int, minor: Int) extends VersionBase[Version, Ex
 
 object Version extends VersionCompanion[Version, ExtendedVersion] with Of[Dot[Version]] {
   override private[versions] val ordering: Ordering[Version] =
-    Ordering.by[Version, (Int, Int)](v => v.major -> v.minor)
+    Ordering.by[Version, Int](_.major)
+      .orElseBy(_.minor)
 
   override def of(major: Int): Dot[Version] = minor => apply(major, minor)
 

--- a/src/main/scala/com/nthportal/versions/v2/Version.scala
+++ b/src/main/scala/com/nthportal/versions/v2/Version.scala
@@ -21,8 +21,7 @@ final case class Version(major: Int, minor: Int) extends VersionBase[Version, Ex
 
 object Version extends VersionCompanion[Version, ExtendedVersion] with Of[Dot[Version]] {
   override private[versions] val ordering: Ordering[Version] =
-    Ordering.by[Version, Int](_.major)
-      .thenBy(_.minor)
+    Ordering.by[Version, (Int, Int)](v => v.major -> v.minor)
 
   override def of(major: Int): Dot[Version] = minor => apply(major, minor)
 

--- a/src/main/scala/com/nthportal/versions/v3/Version.scala
+++ b/src/main/scala/com/nthportal/versions/v3/Version.scala
@@ -25,7 +25,9 @@ final case class Version(major: Int, minor: Int, patch: Int) extends VersionBase
 
 object Version extends VersionCompanion[Version, ExtendedVersion] with Of[Dot[Dot[Version]]] {
   override private[versions] val ordering: Ordering[Version] =
-    Ordering.by[Version, (Int, Int, Int)](v => (v.major, v.minor, v.patch))
+    Ordering.by[Version, Int](_.major)
+      .orElseBy(_.minor)
+      .orElseBy(_.patch)
 
   override def of(major: Int): Dot[Dot[Version]] = minor => patch => apply(major, minor, patch)
 

--- a/src/main/scala/com/nthportal/versions/v3/Version.scala
+++ b/src/main/scala/com/nthportal/versions/v3/Version.scala
@@ -25,9 +25,7 @@ final case class Version(major: Int, minor: Int, patch: Int) extends VersionBase
 
 object Version extends VersionCompanion[Version, ExtendedVersion] with Of[Dot[Dot[Version]]] {
   override private[versions] val ordering: Ordering[Version] =
-    Ordering.by[Version, Int](_.major)
-      .thenBy(_.minor)
-      .thenBy(_.patch)
+    Ordering.by[Version, (Int, Int, Int)](v => (v.major, v.minor, v.patch))
 
   override def of(major: Int): Dot[Dot[Version]] = minor => patch => apply(major, minor, patch)
 

--- a/src/main/scala/com/nthportal/versions/v4/Version.scala
+++ b/src/main/scala/com/nthportal/versions/v4/Version.scala
@@ -23,7 +23,10 @@ final case class Version(_1: Int, _2: Int, _3: Int, _4: Int) extends VersionBase
 
 object Version extends VersionCompanion[Version, ExtendedVersion] with Of[Dot[Dot[Dot[Version]]]] {
   override private[versions] val ordering: Ordering[Version] =
-    Ordering.by[Version, (Int, Int, Int, Int)](v => (v._1, v._2, v._3, v._4))
+    Ordering.by[Version, Int](_._1)
+      .orElseBy(_._2)
+      .orElseBy(_._3)
+      .orElseBy(_._4)
 
   override def of(_1: Int): Dot[Dot[Dot[Version]]] = _2 => _3 => _4 => apply(_1, _2, _3, _4)
 

--- a/src/main/scala/com/nthportal/versions/v4/Version.scala
+++ b/src/main/scala/com/nthportal/versions/v4/Version.scala
@@ -23,10 +23,7 @@ final case class Version(_1: Int, _2: Int, _3: Int, _4: Int) extends VersionBase
 
 object Version extends VersionCompanion[Version, ExtendedVersion] with Of[Dot[Dot[Dot[Version]]]] {
   override private[versions] val ordering: Ordering[Version] =
-    Ordering.by[Version, Int](_._1)
-      .thenBy(_._2)
-      .thenBy(_._3)
-      .thenBy(_._4)
+    Ordering.by[Version, (Int, Int, Int, Int)](v => (v._1, v._2, v._3, v._4))
 
   override def of(_1: Int): Dot[Dot[Dot[Version]]] = _2 => _3 => _4 => apply(_1, _2, _3, _4)
 


### PR DESCRIPTION
* upgrade extra-predef & scalatest
* upgrade sbt and plugins
* don't cross build for multiple scala 2.12 releases
* ci: don't run build with multiple scala 2.12 releases
* ci: switch from oraclejdk8 to openjdk11
* update README

This PR depends on https://github.com/NthPortal/extra-predef/pull/18.